### PR TITLE
Fix button triggering submit when in form

### DIFF
--- a/motion.js
+++ b/motion.js
@@ -43,7 +43,8 @@
         // Play/pause HTML-button
         this.playPauseBtn = H.createElement('button', {
             id: 'play-pause-button',
-            title: 'play'
+            title: 'play',
+            type: 'button'
         }, null, this.playControls, null);
         this.playPauseBtn.className = this.options.playIcon;
 


### PR DESCRIPTION
Explicitly add a `type`-attribute to button, to prevent surrounding forms from being unintentionally triggered by a click on the `play` button.